### PR TITLE
feat: do not process if there is no amount to unstake to network

### DIFF
--- a/contracts/lst_staking_hub/src/unstake.rs
+++ b/contracts/lst_staking_hub/src/unstake.rs
@@ -149,6 +149,10 @@ pub fn execute_process_undelegations(mut deps: DepsMut, env: Env) -> LstResult<R
     // load current batch
     let mut current_batch = CURRENT_BATCH.load(deps.storage)?;
 
+    if current_batch.requested_lst_token_amount == Uint128::zero() {
+        return Ok(Response::new());
+    }
+
     let (messages, events) =
         check_for_unstake_batch_epoch_completion(&mut deps, &env, &mut current_batch)?;
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR optimizes the process of undelegation calculation. We don't need to process if there is no amount to process in the batch.