### PR TITLE
chore: refactor lst_token

### DIFF
--- a/contracts/lst_token/src/bin/schema.rs
+++ b/contracts/lst_token/src/bin/schema.rs
@@ -1,11 +1,11 @@
 use cosmwasm_schema::write_api;
 
 use cw20_base::msg::{ExecuteMsg, QueryMsg};
-use lst_token::msg::TokenInitMsg;
+use lst_token::msg::InstantiateMsg;
 
 fn main() {
     write_api! {
-        instantiate: TokenInitMsg,
+        instantiate: InstantiateMsg,
         execute: ExecuteMsg,
         query: QueryMsg,
     }

--- a/contracts/lst_token/src/msg.rs
+++ b/contracts/lst_token/src/msg.rs
@@ -3,11 +3,10 @@ use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 
 #[cw_serde]
-pub struct TokenInitMsg {
+pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
-    pub initial_balances: Vec<Cw20Coin>,
     pub hub_contract: String,
     pub marketing: Option<InstantiateMarketingInfo>,
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

- Use `cw2::ensure_from_older_version` for migration.
- Use standardized `InstantiateMsg` instead of `TokenInitMsg` rename the conflicting to `CW20InstantiateMsg`
- Remove `initial_balances` so no initial balances is accidentally created.