### PR TITLE
chore: mark schema json files as auto generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark schema JSON files as generated
+contracts/*/schema/*.json linguist-generated=true
+contracts/*/schema/raw/*.json linguist-generated=true 


### PR DESCRIPTION
#### What this PR does / why we need it:
The JSON files will be marked as auto-generated in future PRs