### PR TITLE
chore: update contract_version in schema to match cargo

### DIFF
--- a/contracts/lst_reward_dispatcher/schema/lst_reward_dispatcher.json
+++ b/contracts/lst_reward_dispatcher/schema/lst_reward_dispatcher.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "lst_reward_dispatcher",
-  "contract_version": "1.0.0-alpha1",
+  "contract_version": "1.0.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/lst_staking_hub/schema/lst_staking_hub.json
+++ b/contracts/lst_staking_hub/schema/lst_staking_hub.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "lst_staking_hub",
-  "contract_version": "1.0.0-alpha1",
+  "contract_version": "1.0.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/lst_token/schema/lst_token.json
+++ b/contracts/lst_token/schema/lst_token.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "lst_token",
-  "contract_version": "1.0.0-alpha1",
+  "contract_version": "1.0.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/lst_validators_registry/schema/lst_validators_registry.json
+++ b/contracts/lst_validators_registry/schema/lst_validators_registry.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "lst_validators_registry",
-  "contract_version": "1.0.0-alpha1",
+  "contract_version": "1.0.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
#### What this PR does / why we need it:

```diff
-   "contract_version": "1.0.0-alpha1",
+   "contract_version": "1.0.0",
```