### PR TITLE
chore: refactor migrate entry_point

### DIFF
--- a/contracts/lst_reward_dispatcher/src/contract.rs
+++ b/contracts/lst_reward_dispatcher/src/contract.rs
@@ -177,12 +177,12 @@ fn query_config(deps: Deps) -> LstResult<Config> {
     Ok(CONFIG.load(deps.storage)?)
 }
 
+/// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
+/// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> LstResult<Response> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    Ok(Response::default().add_attribute("migrate", "successful"))
+    Ok(Response::default())
 }
 
 fn compute_fee(amount: Uint128, fee_rate: Decimal) -> Uint128 {

--- a/contracts/lst_staking_hub/src/contract.rs
+++ b/contracts/lst_staking_hub/src/contract.rs
@@ -426,12 +426,12 @@ fn withdraw_all_rewards(
     Ok(messages)
 }
 
+/// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
+/// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> LstResult<Response> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    Ok(Response::default().add_attribute("migrate", "successful"))
+    Ok(Response::default())
 }
 
 fn prepare_wrapped_begin_redelegate_msg(

--- a/contracts/lst_staking_hub/src/contract.rs
+++ b/contracts/lst_staking_hub/src/contract.rs
@@ -429,7 +429,7 @@ fn withdraw_all_rewards(
 /// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
 /// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> LstResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/lst_token/src/contract.rs
+++ b/contracts/lst_token/src/contract.rs
@@ -20,7 +20,7 @@ use cw20_base::{
 };
 
 use lst_common::hub::ExecuteMsg::CheckSlashing;
-use lst_common::types::LstResult;
+
 use crate::{msg::InstantiateMsg, state::HUB_CONTRACT};
 
 const CONTRACT_NAME: &str = concat!("crates.io:", env!("CARGO_PKG_NAME"));
@@ -132,7 +132,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 /// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
 /// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: lst_common::MigrateMsg) -> LstResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/lst_token/src/contract.rs
+++ b/contracts/lst_token/src/contract.rs
@@ -20,7 +20,7 @@ use cw20_base::{
 };
 
 use lst_common::hub::ExecuteMsg::CheckSlashing;
-
+use lst_common::types::LstResult;
 use crate::{msg::InstantiateMsg, state::HUB_CONTRACT};
 
 const CONTRACT_NAME: &str = concat!("crates.io:", env!("CARGO_PKG_NAME"));
@@ -129,8 +129,10 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     cw20_query(deps, env, msg)
 }
 
+/// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
+/// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: lst_common::MigrateMsg) -> LstResult<Response> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/lst_validators_registry/src/contract.rs
+++ b/contracts/lst_validators_registry/src/contract.rs
@@ -84,7 +84,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> L
 /// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
 /// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> LstResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/lst_validators_registry/src/contract.rs
+++ b/contracts/lst_validators_registry/src/contract.rs
@@ -81,12 +81,12 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> L
     }
 }
 
+/// This can only be called by the contract ADMIN, enforced by `wasmd` separate from cosmwasm.
+/// See https://github.com/CosmWasm/cosmwasm/issues/926#issuecomment-851259818
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> LstResult<Response> {
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    Ok(Response::default().add_attribute("migrate", "successful"))
+    Ok(Response::default())
 }
 
 fn add_validator(


### PR DESCRIPTION
#### What this PR does / why we need it:

Ensure `cw2::ensure_from_older_version` used properly.
`ensure_from_older_version` will call `set_contract_version` under the hood, we don't need to call it again.

Closes CUBE-1
