### PR TITLE
chore: #[cfg(not(tarpaulin_include))]

### DIFF
--- a/contracts/lst_reward_dispatcher/src/bin/schema.rs
+++ b/contracts/lst_reward_dispatcher/src/bin/schema.rs
@@ -2,6 +2,7 @@ use cosmwasm_schema::write_api;
 
 use lst_common::rewards_msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
+#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,

--- a/contracts/lst_staking_hub/src/bin/schema.rs
+++ b/contracts/lst_staking_hub/src/bin/schema.rs
@@ -2,6 +2,7 @@ use cosmwasm_schema::write_api;
 
 use lst_common::hub::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
+#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,

--- a/contracts/lst_token/src/bin/schema.rs
+++ b/contracts/lst_token/src/bin/schema.rs
@@ -3,6 +3,7 @@ use cosmwasm_schema::write_api;
 use cw20_base::msg::{ExecuteMsg, QueryMsg};
 use lst_token::msg::InstantiateMsg;
 
+#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,

--- a/contracts/lst_validators_registry/src/bin/schema.rs
+++ b/contracts/lst_validators_registry/src/bin/schema.rs
@@ -2,6 +2,7 @@ use cosmwasm_schema::write_api;
 
 use lst_common::validator::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
+#[cfg(not(tarpaulin_include))]
 fn main() {
     write_api! {
         instantiate: InstantiateMsg,


### PR DESCRIPTION
#### What this PR does / why we need it:

Ignore `fn main() {` in `schema.rs`.